### PR TITLE
fix stop images

### DIFF
--- a/demo/libs/js/app/main.js
+++ b/demo/libs/js/app/main.js
@@ -155,7 +155,7 @@ function onEachFeature(feature, layer) {
 		popUpContent += "<h5>Parada: #"+unit+"</h5>";
       	popUpContent += "<ul>";
       	popUpContent += "<li>Ubicación: "+location+"</li>";
-      	popUpContent += "<li class='img'><img src='/mapaton-demo/libs/images/stops/"+unit+".png'/></li>";
+      	popUpContent += "<li class='img'><img src='libs/images/stops/"+unit+".png'/></li>";
       	popUpContent += "</ul>";
 		layer.bindPopup(popUpContent, customOptions);
 


### PR DESCRIPTION
Las imágenes de las rutas no se podían visualizar en el demo debido a que la ruta de la carpeta contenedora no estaba actualizada